### PR TITLE
replace /image endpoint with /upload

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,7 @@ async function main() {
 function uploadToImgur(img_path, description, clientId) {
   const axiosConfig = {
     method: "post",
-    url: "https://api.imgur.com/3/image",
+    url: "https://api.imgur.com/3/upload",
     headers: {
       "Authorization": `Client-ID ${clientId}`
     },


### PR DESCRIPTION
This hopefully fixes #16. In my tests the /upload endpoint turned out more reliable. I would suggest to try it and see how well it behaves.