### PR TITLE
Also include input paths in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ description:
 **Output**
 
 ```plaintext
+  input_paths:
+    description: 'The local paths to the input images that were uploaded.'
+    example: '["./img1.png", "./img2.png"]'
   imgur_urls: 
     description: 'The urls to the images as a JSON.stringified array.'
     example: '["https://i.imgur.com/j1KnFp1.png", "https://i.imgur.com/UfhRqDR.png"]'

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,8 @@ inputs:
     default: "Images uploaded by public-upload-to-imgur GitHub Action"
     required: false
 outputs:
+  input paths:
+    description: 'The local paths to the input images that were uploaded.'
   imgur_urls: 
     description: 'The urls to the images as a JSON.stringified array.'
   markdown_urls:

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ async function main() {
     })
   )
 
+  core.setOutput("input_paths", JSON.stringify(img_paths))
   core.setOutput("imgur_urls", JSON.stringify(links))
   let markdown_urls = links.map(link => `![Imgur Images](${link})`)
   core.setOutput("markdown_urls", JSON.stringify(markdown_urls))


### PR DESCRIPTION
When a whole directory or a set of globbed paths is used as input, it's helpful to also have the original paths output in the same order so the input and output paths can be easily matched.